### PR TITLE
Add rule config for no-self-assign

### DIFF
--- a/index.js
+++ b/index.js
@@ -189,6 +189,11 @@ module.exports = {
 		// 'no-return-assign': 'off',
 		'no-return-await': 'error',
 		'no-script-url': 'error',
+		'no-self-assign': [
+			'error', {
+				'props': true
+			}
+		],
 		'no-self-compare': 'error',
 		// 'no-sequences': 'off',
 		// 'no-shadow': 'off',


### PR DESCRIPTION
The latest config of _"eslint:recommended"_ contains an error definition with name [no-self-assign](https://eslint.org/docs/rules/no-self-assign). This changes the error reporting only for direct assignments but allows assignments to properties.